### PR TITLE
Add support for 'tableClass' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ For example, this is an example of content corresponding to the name and address
 ]
 ```
 
-### Adding a CSS Class / Setting a Height
+### Adding Custom CSS Classes / Setting a Height
 
-The primary feature of the Fixtable library is its ability to allow scrollable content with a fixed header and footer. To enable this feature, all you need to do is pass in a CSS class with a defined height through the `fixtableClass` property.
+The primary feature of the Fixtable library is its ability to allow scrollable content with a fixed header and footer. To enable this feature, all you need to do is pass in a CSS class with a defined height through the `fixtableClass` property. The class (or classes, if you pass in a space-delimited class name string) specified in `fixtableClass` will be added to the Fixtable container element.
 
 For example:
 ```css
@@ -86,11 +86,19 @@ For example:
 }
 ```
 
+At its core, the Fixtable is an HTML table element. If you want to customize the look of the Fixtable by adding CSS classes directly to the table element, you can do that with the `tableClass` property. For example, we might want to add the `table-hover` class to add Bootstrap's default styles when you hover over a row in the table.
+
+```handlebars
+{{fixtable-grid tableClass='table-hover'}}
+```
+
+By default, Fixtable already adds the `table` CSS class to the table element. As a result, you do **not** need to pass `table` to the `tableClass` property.
+
 ### Putting it All Together
 Let's say that we defined column definitions and grid content on our model as `columnDefs` and `dataRows` respectively. Let's also say that we have a `restrict-height` CSS class that we want to apply to the Fixtable to limit its height and make the content scrollable. In this example, our markup for the `fixtable-grid` component would look like this:
 
 ```handlebars
-{{fixtable-grid columns=model.columnDefs content=model.dataRows fixtableClass='restrict-height'}}
+{{fixtable-grid columns=model.columnDefs content=model.dataRows fixtableClass='restrict-height' tableClass='table-hover'}}
 ```
 
 ## Development / Contributing

--- a/app/templates/components/fixtable-grid.hbs
+++ b/app/templates/components/fixtable-grid.hbs
@@ -4,7 +4,7 @@
     <!-- filter fields go here -->
   </div>
   <div class="fixtable-inner">
-    <table class="table">
+    <table class={{if tableClass (concat 'table ' tableClass) 'table'}}>
       <thead>
         <tr class="fixtable-column-headers">
           {{#each columns as |column|}}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-sass": "^0.7.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -16,6 +16,7 @@ export default Ember.Route.extend({
         { name: 'Morgoth', address: 'Thangorodrim' },
         { name: 'Manwe', address: 'Valinor' },
         { name: 'Homer Simpson', address: 'Springfield, Illinois' },
+        { name: 'Darth Revan' },
         { name: 'Spongebob Squarepants', address: 'A Pineapple Under the Sea' },
         { name: 'Fitzwilliam Darcy', address: 'Pemberley' },
         { name: 'Nessie', address: 'Loch Ness' },
@@ -27,6 +28,8 @@ export default Ember.Route.extend({
         { name: 'Jor-El', address: 'Krypton' },
         { name: 'Oliver Twist' },
         { name: 'Artemis Fowl', address: 'Fowl Manor' },
+        { name: 'Roland Deschain' },
+        { name: 'Han Solo', address: 'Coruscant' }
       ]
     };
   }

--- a/tests/dummy/app/styles/_colors.scss
+++ b/tests/dummy/app/styles/_colors.scss
@@ -1,0 +1,9 @@
+$pure-blue: hsl(195, 45%, 49%);
+
+$body-background-color: hsl(0, 0%, 96.5%);
+$text-color: hsl(0, 0%, 29.8%);
+
+$table-border-color: hsl(0, 0%, 87%);
+$table-body-color: hsl(0, 0%, 100%);
+$table-gradient-color: hsl(0, 0%, 95%);
+$table-hover-color: hsl(57, 82%, 96%);

--- a/tests/dummy/app/styles/_fixtable.scss
+++ b/tests/dummy/app/styles/_fixtable.scss
@@ -1,0 +1,42 @@
+@import 'colors';
+
+.fixtable {
+  .fixtable-header {
+    background: -webkit-linear-gradient(top, $table-body-color 0%, $table-gradient-color 100%);
+    background: -moz-linear-gradient(top, $table-body-color 0%, $table-gradient-color 100%);
+    background: -ms-linear-gradient(top, $table-body-color 0%, $table-gradient-color 100%);
+    background: -o-linear-gradient(top, $table-body-color 0%, $table-gradient-color 100%);
+    background: linear-gradient(top, $table-body-color 0%, $table-gradient-color 100%);
+  }
+
+  table.table {
+    border: 1px solid $table-border-color;
+
+    thead {
+      tr {
+        th {
+          border-bottom: 2px solid $pure-blue;
+        }
+      }
+    }
+
+    tbody {
+      tr {
+        background-color: $table-body-color;
+      }
+    }
+
+    &.table-hover {
+      tbody {
+        tr:hover {
+          background-color: $table-hover-color;
+
+          td:first-child, th:first-child {
+            -webkit-box-shadow:inset 3px 0 0 0 $pure-blue;
+            box-shadow:inset 3px 0 0 0 $pure-blue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,3 +1,0 @@
-.restrict-height {
-  height: 300px;
-}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,0 +1,11 @@
+@import 'colors';
+@import 'fixtable';
+
+body {
+  color: $text-color;
+  background-color: $body-background-color;
+}
+
+.restrict-height {
+  height: 400px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,4 @@
-<h2 id="title">Fixtable-Ember Test</h2>
-{{outlet}}
+<div class="container">
+  <h2 id="title">Fixtable-Ember Test</h2>
+  {{outlet}}
+</div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,1 +1,4 @@
-{{fixtable-grid columns=model.columnDefs content=model.dataRows fixtableClass='restrict-height'}}
+<div class="col-md-6">
+  {{fixtable-grid columns=model.columnDefs content=model.dataRows
+    fixtableClass='restrict-height' tableClass='table-hover' }}
+</div>


### PR DESCRIPTION
This adds the specified CSS class(es) directly to the table element. I also updated the styles of the dummy app's {{fixtable-grid}} to demo the 'tableClass' property.