### PR TITLE
Show a "No data available" message

### DIFF
--- a/app/templates/components/fixtable-grid.hbs
+++ b/app/templates/components/fixtable-grid.hbs
@@ -66,6 +66,10 @@
       {{#if isLoading}}
         <i class="fa fa-refresh fa-spin fa-4x fa-fw" aria-hidden="true"></i>
         <span class="sr-only">Loading...</span>
+      {{else}}
+        {{#unless visibleContent.length}}
+          <h4>No data available</h4>
+        {{/unless}}
       {{/if}}
     </div>
   </div>

--- a/vendor/styles/fixtable-ember.css
+++ b/vendor/styles/fixtable-ember.css
@@ -6,7 +6,7 @@
 }
 
 .fixtable .fixtable-column-filters th .form-group .form-control {
-  border-right-width: 0;
+  border-right: none;
 }
 
 .fixtable .fixtable-column-filters th .form-group .input-group-addon {


### PR DESCRIPTION
Message is shown when 1) there are no rows to be shown, and 2) the loading indicator is not being shown. Fix to issue #22.