### PR TITLE
Disable pager buttons when appropriate

### DIFF
--- a/addon/components/fixtable-grid.js
+++ b/addon/components/fixtable-grid.js
@@ -146,13 +146,17 @@ export default Ember.Component.extend({
       return Math.ceil(this.get('totalRows') / this.get('pageSize'));
     }),
 
+  validatePageNumberRange(unvalidated) {
+    return Math.min(Math.max(1, unvalidated), this.get('totalPages'));
+  },
+
   actions: {
     goToPreviousPage() {
-      this.set('currentPage', Math.max(1, this.get('currentPage') - 1));
+      this.set('currentPage', this.validatePageNumberRange(this.get('currentPage') - 1));
     },
 
     goToNextPage() {
-      this.set('currentPage', Math.min(this.get('totalPages'), this.get('currentPage') + 1));
+      this.set('currentPage', this.validatePageNumberRange(this.get('currentPage') + 1));
     },
 
     applyManualFilter() {

--- a/app/templates/components/fixtable-grid.hbs
+++ b/app/templates/components/fixtable-grid.hbs
@@ -85,11 +85,11 @@
   {{#if showPaging}}
     <div class="fixtable-footer">
       <span>Page</span>
-      <button type="button" class="btn btn-default" aria-label="Previous Page" {{action 'goToPreviousPage'}}>
+      <button type="button" class="btn btn-default" aria-label="Previous Page" {{action 'goToPreviousPage'}} disabled={{equals currentPage 1}}>
         <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
       </button>
-      {{input class="form-control" value=currentPage}}
-      <button type="button" class="btn btn-default" aria-label="Next Page" {{action 'goToNextPage'}}>
+      {{input type="number" class="form-control" value=currentPage}}
+      <button type="button" class="btn btn-default" aria-label="Next Page" {{action 'goToNextPage'}} disabled={{equals currentPage totalPages}}>
         <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
       </button>
       <span>of {{totalPages}}</span>

--- a/vendor/styles/fixtable-ember.css
+++ b/vendor/styles/fixtable-ember.css
@@ -33,6 +33,12 @@
   text-align: center;
 }
 
+.fixtable .fixtable-footer input[type=number]::-webkit-inner-spin-button,
+.fixtable .fixtable-footer input[type=number]::-webkit-outer-spin-button { 
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .fixtable .fixtable-footer select.form-control {
   width: 55px;
 }


### PR DESCRIPTION
Disable the previous pager button on the first page. Disable the forward pager button on the last page. Change page input to number-type.