### PR TITLE
load data on first page load

### DIFF
--- a/addon/components/fixtable-grid.js
+++ b/addon/components/fixtable-grid.js
@@ -372,6 +372,8 @@ export default Ember.Component.extend({
     });
 
     this.set('fixtable', fixtable);
+    
+    this.notifyReloadContent();
   },
 
   didRender() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixtable-ember",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Ember wrapper for the Fixtable table library",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
NotifyReloadContent will call the registered onReloadContent handler thus triggering a data load on initial page load. This is significant for server paging to trigger the initial call to the api with the correct values for page and pageSize.