### PR TITLE
Load font awesome from npm

### DIFF
--- a/blueprints/fixtable-ember/index.js
+++ b/blueprints/fixtable-ember/index.js
@@ -2,7 +2,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall() {
-    return this.addBowerPackageToProject('font-awesome')
-      .then(() => this.addBowerPackageToProject('fixtable'));
+    return this.addBowerPackageToProject('fixtable');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "fixtable": "^1.3.11",
-    "font-awesome": "^4.6.2"
+    "fixtable": "^1.3.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-funnel": "^1.0.8",
+    "broccoli-merge-trees": "^1.1.4",
     "broccoli-sass": "^0.7.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.5.0",
@@ -42,6 +44,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
+    "font-awesome": "^4.7.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
Moving font-awesome from being loaded by bower to being loaded by npm.  

The internal ember addon for purecloud apps, ember-purecloud-components, loads font-awesome via npm in a similar way to this PR.  When importing through bower we get an error because both the npm and bower imports put the fonts in the /vendor/fonts directory.  While we can specify { overwrite: true } when merging npm files, we have no control over the bower merge.  

So the change here is to move away from using bower and bring in font-awesome through npm.  Ember is moving away from requiring bower as a dependency, so I think this is a good long term update, as well as fixing the conflict issue we are facing.