### PR TITLE
Extract footer markup into a separate component

### DIFF
--- a/addon/components/fixtable-footer.js
+++ b/addon/components/fixtable-footer.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import layout from '../templates/components/fixtable-footer';
+
+export default Ember.Component.extend({
+  layout,
+  classNames: ['fixtable-footer'],
+  currentPage: null,
+  totalPages: null,
+  pageSize: null,
+  pageSizeOptions: null,
+
+  actions: {
+    goToPreviousPage() {
+      this.sendAction("goToPreviousPage");
+    },
+    goToNextPage() {
+      this.sendAction("goToNextPage");
+    }
+  }
+});

--- a/addon/templates/components/fixtable-footer.hbs
+++ b/addon/templates/components/fixtable-footer.hbs
@@ -1,0 +1,20 @@
+<span>Page</span>
+<button type="button" class="btn btn-default" aria-label="Previous Page" {{action 'goToPreviousPage'}} disabled={{equals currentPage 1}}>
+  <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+</button>
+{{input type="number" class="form-control" value=currentPage}}
+<button type="button" class="btn btn-default" aria-label="Next Page" {{action 'goToNextPage'}} disabled={{equals currentPage totalPages}}>
+  <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+</button>
+<span>of {{totalPages}}</span>
+
+<span class="pull-right">
+  <select class="form-control" onchange={{action (mut pageSize) value="target.value"}}>
+    {{#each pageSizeOptions as |choice|}}
+      <option value={{choice}} selected={{equals pageSize choice}}>{{choice}}</option>
+    {{/each}}
+  </select>
+  <span>
+    items per page
+  </span>
+</span>

--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -118,27 +118,8 @@
     </div>
   </div>
   {{#if showPaging}}
-    <div class="fixtable-footer">
-      <span>Page</span>
-      <button type="button" class="btn btn-default" aria-label="Previous Page" {{action 'goToPreviousPage'}} disabled={{equals currentPage 1}}>
-        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-      </button>
-      {{input type="number" class="form-control" value=currentPage}}
-      <button type="button" class="btn btn-default" aria-label="Next Page" {{action 'goToNextPage'}} disabled={{equals currentPage totalPages}}>
-        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-      </button>
-      <span>of {{totalPages}}</span>
-
-      <span class="pull-right">
-        <select class="form-control" onchange={{action (mut pageSize) value="target.value"}}>
-          {{#each pageSizeOptions as |choice|}}
-            <option value={{choice}} selected={{equals pageSize choice}}>{{choice}}</option>
-          {{/each}}
-        </select>
-        <span>
-          items per page
-        </span>
-      </span>
-    </div>
+    {{fixtable-footer
+      currentPage=currentPage totalPages=totalPages pageSize=pageSize pageSizeOptions=pageSizeOptions
+      goToNextPage="goToNextPage" goToPreviousPage="goToPreviousPage"}}
   {{/if}}
 </div>

--- a/app/components/fixtable-footer.js
+++ b/app/components/fixtable-footer.js
@@ -1,0 +1,1 @@
+export { default } from 'fixtable-ember/components/fixtable-footer';

--- a/tests/integration/components/fixtable-footer-test.js
+++ b/tests/integration/components/fixtable-footer-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('fixtable-footer', 'Integration | Component | fixtable footer', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.set('currentPage', 2);
+  this.set('totalPages', 3);
+  this.set('pageSize', 25);
+  this.set('pageSizeOptions', [25, 50, 100]);
+
+  this.render(hbs`{{fixtable-footer currentPage=currentPage totalPages=totalPages pageSize=pageSize pageSizeOptions=pageSizeOptions}}`);
+
+  assert.ok(this.$('.fixtable-footer').length); // there is an element with the fixtable-footer class
+});


### PR DESCRIPTION
No functional difference; just a small refactoring to reduce the size of the fixtable-grid component.