### PR TITLE
Hide pagination footer when there's no visible content

### DIFF
--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -117,7 +117,7 @@
       {{/if}}
     </div>
   </div>
-  {{#if showPaging}}
+  {{#if (and showPaging visibleContent.length)}}
     {{fixtable-footer
       currentPage=currentPage totalPages=totalPages pageSize=pageSize pageSizeOptions=pageSizeOptions
       goToNextPage="goToNextPage" goToPreviousPage="goToPreviousPage"}}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-truth-helpers": "1.2.0",
     "font-awesome": "^4.7.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Hides pagination footer when we show the "no data available" message -- e.g., when no data is loaded at all or the filter conditions exclude all of the rows. This prevents showing weird things like "page 1 of 0" and doesn't remove any functionality since you can't page backwards/forwards if there's no data, anyway.