### PR TITLE
Add a placeholder option to the column filter options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # misc
 /.sass-cache
+/.vscode
 /connect.lock
 /coverage/*
 /libpeerconnection.log

--- a/README.md
+++ b/README.md
@@ -382,6 +382,25 @@ By default, the Fixtable will automatically filter itself as the user types into
 
 To disable real-time filtering, simply set the `realtimeFiltering` property to `false`. The Fixtable will automatically show Apply and Clear buttons that apply or clear the entered filters, respectively.
 
+#### Filter Placeholder Text
+
+Placeholder text set to the value of the `placeholder` property of the `filter` object of the column definition.
+
+```javascript
+[
+  {
+    key: 'name',
+    header: 'Name',
+    filter: {
+      type: 'search',
+      placeholder: 'name search'
+    }
+  }
+]
+```
+
+If the filter is a "search" type, the `placeholder` attribute of the `<input>` element is set to the placeholder value. If the filter is a "select" type, the text of the first `<option>` of the `<select>` element is set to the placeholder value.
+
 #### Filter Caveats
 
 Columns that have a custom cell component can be filtered, but only if the data rows defined in `content` have values corresponding to the column using the custom cell component. The filtering will be based on the data in `content`, not on what's rendered by the custom cell component.

--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -39,7 +39,7 @@
                     <div class='input-group'>
                       {{#if (equals column.filter.type 'select')}}
                         <select class="form-control" onchange={{action (mut (get filters column.key)) value="target.value"}}>
-                          <option value=""></option>
+                          <option value="">{{column.filter.placeholder}}</option>
                           {{#each (getSelectOptions column content serverPaging) as |choice|}}
                             <option value={{choice.value}} selected={{equals (get filters column.key) choice.value}}>
                               {{if choice.label choice.label choice.value}}
@@ -47,7 +47,7 @@
                           {{/each}}
                         </select>
                       {{else}}
-                        {{input class='form-control' type='search' aria-label="Filter by column"
+                        {{input class='form-control' type='search' aria-label="Filter by column" placeholder=column.filter.placeholder
                           value=(mut (get filters column.key))}}
                         <span class="input-group-addon">
                           <span class="glyphicon glyphicon-search" aria-hidden="true"></span>

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -51,12 +51,10 @@ export default Ember.Route.extend({
     // create a version of the column defs that includes filters
     model.filteredColumnDefs = JSON.parse(JSON.stringify(model.columnDefs));
     model.filteredColumnDefs[1].filter = { // name
-      type: 'search',
-      placeholder: 'name'
+      type: 'search'
     };
     model.filteredColumnDefs[2].filter = { // address
-      type: 'search',
-      placeholder: 'address'
+      type: 'search'
     };
     model.filteredColumnDefs[3].filter = { // alignment
       type: 'select',
@@ -64,17 +62,20 @@ export default Ember.Route.extend({
         { value: 'Good', label: 'Positive' },
         { value: 'Evil', label: 'Negative' },
         { value: 'Neutral' }
-      ],
-      placeholder: 'All'
+      ]
     };
 
     // create a version of the filtered column defs that includes automaticOptions
     model.clientColumnDefs = JSON.parse(JSON.stringify(model.filteredColumnDefs));
     model.clientColumnDefs[3].filter = { // alignment
       type: 'select',
-      automaticOptions: true,
-      placeholder: 'All'
+      automaticOptions: true
     };
+
+    model.filteredColumnWithPlaceholderDefs = JSON.parse(JSON.stringify(model.filteredColumnDefs));
+    model.filteredColumnWithPlaceholderDefs[1].filter.placeholder = 'name';
+    model.filteredColumnWithPlaceholderDefs[2].filter.placeholder = 'address';
+    model.filteredColumnWithPlaceholderDefs[3].filter.placeholder = 'All';
 
     // add a custom ID sorting function to both versions of the column defs
     var sortFunc = (x, y) => x - y;

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -50,15 +50,22 @@ export default Ember.Route.extend({
 
     // create a version of the column defs that includes filters
     model.filteredColumnDefs = JSON.parse(JSON.stringify(model.columnDefs));
-    model.filteredColumnDefs[1].filter = { type: 'search' }; // name
-    model.filteredColumnDefs[2].filter = { type: 'search' }; // address
+    model.filteredColumnDefs[1].filter = { // name
+      type: 'search',
+      placeholder: 'name'
+    };
+    model.filteredColumnDefs[2].filter = { // address
+      type: 'search',
+      placeholder: 'address'
+    };
     model.filteredColumnDefs[3].filter = { // alignment
       type: 'select',
       selectOptions: [
         { value: 'Good', label: 'Positive' },
         { value: 'Evil', label: 'Negative' },
         { value: 'Neutral' }
-      ]
+      ],
+      placeholder: 'All'
     };
 
     // create a version of the filtered column defs that includes automaticOptions
@@ -66,6 +73,7 @@ export default Ember.Route.extend({
     model.clientColumnDefs[3].filter = { // alignment
       type: 'select',
       automaticOptions: true,
+      placeholder: 'All'
     };
 
     // add a custom ID sorting function to both versions of the column defs

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -63,6 +63,20 @@
   </div>
 </div>
 
+<h3>Server Paging with Filter Placeholders</h3>
+<p>Like the previous example, this Fixtable has server pagination and filtering enabled. Unlike the previous example, the filters fields contain placeholder text.</p>
+<div class="row">
+  <div class="col-md-8">
+    {{fixtable-grid columns=model.filteredColumnWithPlaceholderDefs content=model.manualFilterVisibleRows sortBy=(mut manualFilterPageSortKey)
+      fixtableClass='restrict-height' tableClass='table-hover'
+      isLoading=manualFilterPageIsLoading serverPaging=true totalRowsOnServer=model.manualFilterDataRows.length
+      onReloadContent=(action 'updateManualFilterPage') }}
+    <button type="button" class="btn btn-primary" {{action 'toggle' 'manualFilterPageIsLoading'}}>
+      Toggle Loading
+    </button>
+  </div>
+</div>
+
 <h3>Row Selection</h3>
 <p>This Fixtable lets you select rows.</p>
 <h4>Selected:</h4>


### PR DESCRIPTION
![screen shot 2016-11-14 at 5 46 45 pm](https://cloud.githubusercontent.com/assets/1877404/20285919/5e490290-aa92-11e6-8e40-95204d9ef7f5.png)

The placeholder option that you specify will set the `placeholder` attribute of the input helper for the 'search' type and will be used for the label of the default option for the 'select' type.