### PR TITLE
Restore sanity to the row selection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,12 +588,11 @@ Selected rows will automatically have the `active` CSS class applied to them. Th
 
 When rows are selected, any kind of content reload (i.e., anything that would trigger `onReloadContent` -- sorting, paging, or filtering) will clear the selected rows. (This is true regardless of whether the Fixtable is using client paging, server paging, or no paging at all.)
 
-Consumers should keep track of which rows are selected by subscribing to `onSelectionChanged` and `onReloadContent`. No selection-related parameters are passed to `onReloadContent`, but a consumer who cares about selection **must** listen to this because any content reload will automatically clear the selection -- and when content is reloaded, `onSelectionChanged` is not called in addition to `onReloadContent`.
+Consumers should keep track of which rows are selected by subscribing to `onSelectionChanged`. Note that whenever the `onReloadContent` handler is called, the `onSelectionChanged` handler will also be invoked immediately afterwards, informing the listener that the selected rows have been cleared out.
 
-`onSelectionChanged` should be bound to an action on the owning controller or component. The bound action will be called whenever a row is selected or deselected. It receives the following two parameters:
+`onSelectionChanged` should be bound to an action on the owning controller or component. The bound action will be called whenever a row is selected or deselected. It receives the following parameter:
 
-* `selectedRows` (Object) - Object where the key/value pairs map row indices to a boolean indicating whether the row is selected.
-* `rowIndex` (String) - The index of the selected row. Note that this is the index relative to the rows loaded into the page, *not* relative to the entire dataset. So, the indices will always fall into the range [0, pageSize).
+* `selectedDataRows` (Object) - The selected data rows.
 
 ## Development / Contributing
 

--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -68,12 +68,12 @@
       <tbody>
         {{#unless isLoading}}
           {{#each visibleContent as |row rowIndex|}}
-            <tr class={{if (get selectedRows (concat '' rowIndex)) 'active'}}>
+            <tr class={{if (get selectedRowMap (concat '' rowIndex)) 'active'}}>
               {{#if rowSelection}}
                 <td>
                   <div class="fixtable-checkbox">
                     {{!-- we need concat here to convert rowIndex into a string for the get helper --}}
-                    {{input type="checkbox" checked=(mut (get selectedRows (concat '' rowIndex)))}}
+                    {{input type="checkbox" checked=(mut (get selectedRowMap (concat '' rowIndex)))}}
                   </div>
                 </td>
               {{/if}}

--- a/tests/dummy/app/controllers/editable.js
+++ b/tests/dummy/app/controllers/editable.js
@@ -130,19 +130,11 @@ export default Ember.Controller.extend({
       this.set('model.dataRows.content', this.get('data').getObservableData());
     },
 
-    onReloadContent() {
-      this.set('selected', {});
-    },
-
-    updateSelection(selectedRows/*, rowIndex*/) {
-      let dataRows = this.get('model.dataRows');
+    updateSelection(selectedDataRows) {
       let selected = {};
-      Object.keys(selectedRows)
-        .filter(key => selectedRows[key])
-        .forEach(key => {
-          let id = dataRows.objectAt(parseInt(key, 10)).get('id');
-          selected[id] = true;
-        });
+      selectedDataRows.forEach(row => {
+        selected[row.id] = true;
+      });
       this.set('selected', selected);
     },
 

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -81,15 +81,8 @@ export default Ember.Controller.extend({
         'serverPageIsLoading', 'model.filteredDataRows', 'model.pagedDataRows');
     },
 
-    rowSelectionReloadContent(/*page, pageSize, filters, sortInfo*/) {
-      this.set('selectedNames', '');
-    },
-
-    updateSelection(selectedRows/*, rowIndex*/) {
-      var selectedNames = [];
-      Object.keys(selectedRows)
-        .filter(key => selectedRows[key])
-        .forEach(key => selectedNames.push(this.get('model.dataRows')[key].name));
+    updateSelection(selectedDataRows) {
+      var selectedNames = selectedDataRows.map(row => row.name);
       this.set('selectedNames', selectedNames.join(', '));
     }
   }

--- a/tests/dummy/app/templates/editable.hbs
+++ b/tests/dummy/app/templates/editable.hbs
@@ -5,8 +5,7 @@
 
 {{fixtable-grid columns=columnDefs content=model.dataRows clientPaging=true
   fixtableClass='editable-fixtable' tableClass='table-hover' rowSelection=true sortBy=(mut sortKey)
-  onReloadContent=(action 'onReloadContent') onSelectionChanged=(action 'updateSelection')
-  purifyRow=(action 'purifyRow') condemnRow=(action 'condemnRow')}}
+  onSelectionChanged=(action 'updateSelection') purifyRow=(action 'purifyRow') condemnRow=(action 'condemnRow')}}
 
 <h3>Delete Selected Rows</h3>
 <button type="button" class="btn btn-primary" {{action 'deleteSelectedRows'}}>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -71,6 +71,6 @@
   <div class="col-md-8">
     {{fixtable-grid columns=model.filteredColumnDefs content=model.dataRows sortBy=(mut rowSelectionSortKey)
       fixtableClass='restrict-height' tableClass='table-hover' clientPaging=true rowSelection=true
-      onSelectionChanged=(action 'updateSelection') onReloadContent=(action 'rowSelectionReloadContent')}}
+      onSelectionChanged=(action 'updateSelection')}}
   </div>
 </div>


### PR DESCRIPTION
This PR changes the row selection handler so that it returns full selected data rows to the consumer, rather than indices into the visible content. (For client filtered/paginated rows, there's simply no easy way for the consumer to know what's in the visible content, which makes the row selection API practically worthless.) Fixes issue #87.

This PR causes breaking changes to the row selection API, so it will require a major version bump to adhere to semver. In particular, these two things have changed:

* The signature of the row selection handler
* When the row selection handler is called (now it's also called whenever onReloadContent is called, instead of requiring the consumer to monitor both events if they only care about selection)