### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixtable-ember",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Ember wrapper for the Fixtable table library",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
When a recent addition to the api for supporting row click was added the version of the package was not bumped.  This bumps the package one minor version.