### PR TITLE
Remove ember-truth-helpers dependency

### DIFF
--- a/addon/components/fixtable-grid.js
+++ b/addon/components/fixtable-grid.js
@@ -21,6 +21,7 @@ export default Ember.Component.extend({
   serverPaging: false,
   showPaging: Ember.computed.or('clientPaging', 'serverPaging'),
   totalRowsOnServer: 0, // only used for server paging
+  showPaginationFooter: Ember.computed.and('showPaging', 'visibleContent.length'),
 
   // filters
   filters: null,

--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -104,7 +104,7 @@
       {{/if}}
     </div>
   </div>
-  {{#if (and showPaging visibleContent.length)}}
+  {{#if showPaginationFooter}}
     {{fixtable-footer
       currentPage=currentPage totalPages=totalPages pageSize=pageSize pageSizeOptions=pageSizeOptions
       goToNextPage="goToNextPage" goToPreviousPage="goToPreviousPage"}}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
-    "ember-truth-helpers": "1.2.0",
     "fixtable": "^2.0.2",
     "font-awesome": "^4.7.0"
   },


### PR DESCRIPTION
Removed our dependency on ember-truth-helpers. Because this addon is commonly used in other addons/engines, it's preferable for us to minimize dependencies that might conflict (in version) with those of the parent app.