### PR TITLE
Use project node modules instead of scoped addon node modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,13 @@ module.exports = {
       parent = parent.app;
     }
 
-    let fontAwesomeToImport = fs.readdirSync(`${this.nodeModulesPath}/font-awesome/fonts`);
+    const nodeModulesPath = parent.project.nodeModulesPath;
+    let fontAwesomeToImport = fs.readdirSync(`${nodeModulesPath}/font-awesome/fonts`);
     fontAwesomeToImport.forEach((fontFileName) => {
       parent.import(path.join('vendor', 'fonts', fontFileName));
     });
 
-    parent.import(path.join(this.nodeModulesPath, 'fixtable/dist/fixtable.js'));
+    parent.import(path.join(nodeModulesPath, 'fixtable/dist/fixtable.js'));
 
     parent.import('vendor/styles/fixtable-ember.css');
     parent.import('vendor/styles/font-awesome.css');


### PR DESCRIPTION
This fixes the intermittent issue described in #94. When fixtable-ember is a child dependency of another addon inside of a larger application, the node_modules folder it references is incorrect. This always uses the project node_modules folder.