### PR TITLE
change from using app.import to this.import

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,24 +9,19 @@ const path = require('path');
 module.exports = {
   name: 'fixtable-ember',
 
-  included(parent) {
+  included() {
     this._super.included.apply(this, arguments);
-
-    // Find the top-level app if this is nested within other addons
-    while (parent.app) {
-      parent = parent.app;
-    }
 
     let fontAwesomeToImport = fs.readdirSync(`${this.nodeModulesPath}/font-awesome/fonts`);
     fontAwesomeToImport.forEach((fontFileName) => {
-      parent.import(path.join('vendor', 'fonts', fontFileName));
+      this.import(path.join('vendor', 'fonts', fontFileName));
     });
 
-    parent.import(path.join(this.nodeModulesPath, 'fixtable/dist/fixtable.js'));
+    this.import(path.join(this.nodeModulesPath, 'fixtable/dist/fixtable.js'));
 
-    parent.import('vendor/styles/fixtable-ember.css');
-    parent.import('vendor/styles/font-awesome.css');
-    parent.import('vendor/styles/fixtable.css');
+    this.import('vendor/styles/fixtable-ember.css');
+    this.import('vendor/styles/font-awesome.css');
+    this.import('vendor/styles/fixtable.css');
   },
 
   treeForVendor(tree) {


### PR DESCRIPTION
using `this.import` is the preferred way of importing dependencies, especially when nesting addons.  I'm hoping that this fix will help some of our font awesome dependency issues in our consuming app (web-directory)


see https://github.com/ember-cli/ember-cli/pull/5877