### PR TITLE
Fix cutoff of last row

### DIFF
--- a/addon/components/fixtable-footer.js
+++ b/addon/components/fixtable-footer.js
@@ -8,6 +8,10 @@ export default Ember.Component.extend({
   totalPages: null,
   pageSize: null,
   pageSizeOptions: null,
+  nextDisabled: Ember.computed('currentPage', 'totalPages', function() {
+    let { currentPage, totalPages } = this.getProperties('currentPage', 'totalPages');
+    return currentPage >= totalPages;
+  }),
 
   actions: {
     goToPreviousPage() {

--- a/addon/components/fixtable-grid.js
+++ b/addon/components/fixtable-grid.js
@@ -21,7 +21,6 @@ export default Ember.Component.extend({
   serverPaging: false,
   showPaging: Ember.computed.or('clientPaging', 'serverPaging'),
   totalRowsOnServer: 0, // only used for server paging
-  showPaginationFooter: Ember.computed.and('showPaging', 'visibleContent.length'),
 
   // filters
   filters: null,

--- a/addon/templates/components/fixtable-footer.hbs
+++ b/addon/templates/components/fixtable-footer.hbs
@@ -3,7 +3,7 @@
   <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 </button>
 {{input type="number" class="form-control" value=currentPage min=1 max=totalPages}}
-<button type="button" class="btn btn-default" aria-label="Next Page" {{action 'goToNextPage'}} disabled={{equals currentPage totalPages}}>
+<button type="button" class="btn btn-default" aria-label="Next Page" {{action 'goToNextPage'}} disabled={{nextDisabled}}>
   <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 </button>
 <span>of {{totalPages}}</span>

--- a/addon/templates/components/fixtable-grid.hbs
+++ b/addon/templates/components/fixtable-grid.hbs
@@ -104,7 +104,7 @@
       {{/if}}
     </div>
   </div>
-  {{#if showPaginationFooter}}
+  {{#if showPaging}}
     {{fixtable-footer
       currentPage=currentPage totalPages=totalPages pageSize=pageSize pageSizeOptions=pageSizeOptions
       goToNextPage="goToNextPage" goToPreviousPage="goToPreviousPage"}}


### PR DESCRIPTION
This PR fixes the problem of the last line being covered by the paging controls.

<img width="649" alt="screen shot 2017-09-14 at 6 05 11 pm" src="https://user-images.githubusercontent.com/1877404/30494078-bf158fb8-9a14-11e7-9aad-108607e0942d.png">

That is happening because the code in the `fixtable-core` component searches the DOM for the footer element _before_ the Ember component resolves the computed property, `fixtable-grid.js`/`showPaginationFooter` that indicates whether or not to display the footer resolves to true.

The `showPaginationFooter` was calculated based on the existence of results. This PR changes that so the paging control will still be displayed if there are no results. To mitigate that potential awkwardness, it makes sure the previous and next buttons are disabled when there are no results.

![screen shot 2017-09-15 at 12 58 56 pm](https://user-images.githubusercontent.com/1877404/30494337-b00345b4-9a15-11e7-88a7-3f51608eb7d8.png)
