### PR TITLE
harden visibleContent property against being passed a non-array

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here's an example using percentage width:
 
 ### Defining Content
 
-The component expects a `content` property to be passed in. This should be an array of objects.
+The component expects a `content` property to be passed in. This should be an array of objects, either a native `Array` or one of Ember's Array-like objects (`Ember.ArrayProxy`, `DS.ManyArray`, or their subclasses).
 * Each object element in the array represents a row of data.
 * Each key/value pair in a row object represents a single cell of data. The key should match a key defined in `columns`, and the value represents the content for the column/row intersection.
 * If there is no data for a given column, that key/value pair can be omitted from the row object.

--- a/addon/components/fixtable-grid.js
+++ b/addon/components/fixtable-grid.js
@@ -227,10 +227,10 @@ export default Ember.Component.extend({
 
       // ensure sortedFilteredContent is a supported type
       let allowedTypes = [Array, Ember.ArrayProxy, DS.ManyArray];
-      let matchingTypes = allowedTypes.filter(function (type) {
+      let isAllowedType = allowedTypes.some(function (type) {
         return sortedFilteredContent instanceof type;
       });
-      if (!matchingTypes.length) {
+      if (!isAllowedType) {
         Ember.Logger.warn('Content supplied to Fixtable is not a supported type');
         return [];
       }

--- a/addon/components/fixtable-grid.js
+++ b/addon/components/fixtable-grid.js
@@ -1,5 +1,6 @@
 /* global Fixtable */
 
+import DS from 'ember-data';
 import Ember from 'ember';
 import layout from '../templates/components/fixtable-grid';
 
@@ -222,7 +223,17 @@ export default Ember.Component.extend({
 
   visibleContent: Ember.computed('sortedFilteredContent', 'currentPage', 'pageSize', 'clientPaging',
     function fixtableGrid$visibleContent() {
-      let sortedFilteredContent = this.get('sortedFilteredContent') || [];
+      let sortedFilteredContent = this.get('sortedFilteredContent');
+
+      // ensure sortedFilteredContent is a supported type
+      let allowedTypes = [Array, Ember.ArrayProxy, DS.ManyArray];
+      let matchingTypes = allowedTypes.filter(function (type) {
+        return sortedFilteredContent instanceof type;
+      });
+      if (!matchingTypes.length) {
+        Ember.Logger.warn('Content supplied to Fixtable is not a supported type');
+        return [];
+      }
 
       if (this.get('clientPaging')) {
         let currentPage = this.get('currentPage');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixtable-ember",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Ember wrapper for the Fixtable table library",
   "directories": {
     "doc": "doc",
@@ -55,6 +55,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-data": "^2.15.0",
     "fixtable": "^2.0.2",
     "font-awesome": "^4.7.0"
   },


### PR DESCRIPTION
Changes made in v3.2.0 caused visibleContent computed property to encounter a JavaScript error if the fixtable-grid was supplied any value that wasn't an Array or Array-like object. This has been hardened to ensure that the supplied content is a supported type, and outputs a warning if not. The README has also been updated to make this type requirement explicit.