### PR TITLE
move ember-data to devDeps bc it forces latest on app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixtable-ember",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Ember wrapper for the Fixtable table library",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-data": "^2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
@@ -55,7 +56,6 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
-    "ember-data": "^2.12.0",
     "fixtable": "^2.0.2",
     "font-awesome": "^4.7.0"
   },


### PR DESCRIPTION
This was breaking web-directory when we pick up the latest versions (^3.2.1).  When you put a package in "dependencies" it pushes the provided version onto consuming apps.  In the case of web-directory, we want it to be ~2.14, but since this dependency is ^2.12, it was causing web directory to pick up version 2.15 (latest), causing a breaking change in the app. If you move to devDependencies it lets the consuming app to control the version. 