### PR TITLE
add isDevelopingAddon implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ module.exports = {
     treesToMerge.push(fixtableCssFunnel);
 
     return mergeTrees(treesToMerge, { overwrite: true });
+  },
+
+  isDevelopingAddon() {
+    return false;
   }
 
 };


### PR DESCRIPTION
so linting tools, such as ember-cli-template-lint rely on `isDevelopingAddon` to decide whether to lint addon code.  Seems in recent ember cli releases that it decides that because fixtable does not implement that method, then it will assume "yes" to linting.  We don't want our implementors to have this forced on them, so I'm giving it a default implementation of `false`, and addon developers can change it to true when developing new features.

Currently breaking the web-directory app